### PR TITLE
Use $this->encode to return image.

### DIFF
--- a/src/Cuzzy/Ivatar/Drivers/Gd/Driver.php
+++ b/src/Cuzzy/Ivatar/Drivers/Gd/Driver.php
@@ -86,7 +86,7 @@ class Driver extends AbstractDriver
 
         $this->encode = $buffer;
 
-        return $this;
+        return $this->encode;
     }
 
     public function save()


### PR DESCRIPTION
Had an expected-string-but-got object error when generating Ivatars using gd.  This fixed it.
